### PR TITLE
Specialize walk-list-form on (eql 'cl:lambda)

### DIFF
--- a/src/walker.lisp
+++ b/src/walker.lisp
@@ -282,6 +282,9 @@
 
 ;;; Function forms
 
+(defmethod walk-list-form ((operator (eql 'cl:lambda)) operands env)
+  `(lambda ,@(walk-fn-def operands env)))
+
 (defmethod walk-list-form ((operator (eql 'cl:function)) operands env)
   (match-form operands
     ((list (list* 'cl:lambda def))


### PR DESCRIPTION
I'm unsure if this should be handled here, or in `macroexpand-all`:

```lisp
(defun macroexpand-all (form &optional env)
  (cl-form-types.walker:walk-form (lambda (form env)
                                    (declare (ignore env))
                                    form)
                                  form                                  
                                  env))
```

Before this commit:

```lisp
CL-USER> (macroexpand-all `(lambda ()))
#'(LAMBDA ())
CL-USER> (macroexpand-all `((lambda ())))
((LAMBDA ()))
```

While both `trivial-macroexpand-all:macroexpand-all` (aka SBCL's own) and `macroexpand-dammit:macroexpand-dammit` leave both of the above two cases unchanged. Not sure which is the correct way forward.