### PR TITLE
In LAMBDA-EXPRESSION-TYPE: get the CAR not CDR of AUX variables

### DIFF
--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -776,16 +776,16 @@
 	    (parse-body body :documentation nil)
 
 	  (let ((env (augment-environment
-		      env
+                      env
 		      :variable
-		      (append required
-			      (mappend #'optional-vars optional)
-			      (ensure-list rest)
-			      (mappend #'key-vars key)
-			      (mapcar #'cdr aux))
+                      (append required
+                              (mappend #'optional-vars optional)
+                              (ensure-list rest)
+                              (mappend #'key-vars key)
+                              (mapcar #'car aux))
 
-		      :declare
-		      (mappend #'cdr declarations))))
+                      :declare
+                      (mappend #'cdr declarations))))
 
 	    `(function
 


### PR DESCRIPTION
Existing code errors when the values of auxiliary variables are specified in terms of non-atomic forms. For example, while testing polymorphic-functions on CCL, I get the error:

```lisp
Malformed :VARIABLE list: #1=(((LAMBDA
                                (ARRAY)
                                (ARRAY-ELEMENT-TYPE ARRAY))
                               ARRAY)) is not a symbol in (ARRAY
                                                           ELT
                                                           #1#).
  0: ((:INTERNAL CCL::NX1-COMPILE-LAMBDA) #<CCL::SIMPLE-PROGRAM-ERROR #x3020022C98BD>)
  1: (SIGNAL #<CCL::SIMPLE-PROGRAM-ERROR #x30200219923D>)
  2: (CCL::%ERROR #<CCL::SIMPLE-PROGRAM-ERROR #x30200219923D> NIL 17563241926912)
  3: ((:INTERNAL CCL::CHECK-ALL-SYMBOLS CCL::CHECK-ENVIRONMENT-ARGS) (ARRAY ELT (((LAMBDA # #) ARRAY))) :VARIABLE NIL :SYMBOL-MACRO)
  4: (CCL::CHECK-ENVIRONMENT-ARGS (ARRAY ELT (((LAMBDA # #) ARRAY))) NIL NIL NIL)
  5: (AUGMENT-ENVIRONMENT #<CCL::LEXICAL-ENVIRONMENT #x30200219980D> :VARIABLE (ARRAY ELT (((LAMBDA # #) ARRAY))) :SYMBOL-MACRO NIL :FUNCTION NIL :MACRO NIL :DECLARE ((TYPE SINGLE-FLOAT ELT) ..))
  6: ((:INTERNAL CL-FORM-TYPES::LAMBDA-EXPRESSION-TYPE) ((BLOCK POLYMORPHIC-FUNCTIONS::FOO (LOCALLY (= ELT #)))) ((DECLARE (TYPE SINGLE-FLOAT ELT) (TYPE (SIMPLE-ARRAY SINGLE-FLOAT) ARRAY) ..)) NIL)
  7: ((:INTERNAL CL-FORM-TYPES::LAMBDA-EXPRESSION-TYPE) (ARRAY ELT) NIL NIL NIL NIL ((POLYMORPHIC-FUNCTIONS::<T> ((LAMBDA # #) ARRAY))) NIL)
  8: (CL-FORM-TYPES::LAMBDA-EXPRESSION-TYPE (ARRAY ELT &AUX (POLYMORPHIC-FUNCTIONS::<T> ((LAMBDA # #) ARRAY))) ((DECLARE (TYPE SINGLE-FLOAT ELT) (TYPE (SIMPLE-ARRAY SINGLE-FLOAT) ARRAY) ..))) #<CCL::LEXICA..

```