### PR TITLE
Simplify the output of combine-values-type using subtypep

### DIFF
--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -418,13 +418,9 @@
 		  (append
            (mapcar (lambda (type1 type2)
                      (let ((combined (list combinator type1 type2)))
-                       (cond ((and (not (type= nil type1))
-                                   (subtypep type1 combined)
-                                   (subtypep type1 type2))
+                       (cond ((type= combined type1)
                               type1)
-                             ((and (not (type= nil type2))
-                                   (subtypep type2 combined)
-                                   (subtypep type2 type1))
+                             ((type= combined type2)
                               type2)
                              (t
                               combined))))
@@ -493,7 +489,7 @@
        (list* 'values (combine (list type1) types2)))
 
       ((_ _)
-       (list combinator type1 type2)))))
+       (first (combine (list type1) (list type2)))))))
 
 
 ;;; Basic Form Types

--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -416,7 +416,15 @@
 
 		 (->
 		  (append
-		   (mapcar (curry #'list combinator) types1 types2)
+           (mapcar (lambda (type1 type2)
+                     (let ((combined (list combinator type1 type2)))
+                       (cond ((subtypep type1 combined)
+                              type1)
+                             ((subtypep type2 combined)
+                              type2)
+                             (t
+                              combined))))
+                   types1 types2)
 		   (mapcar (curry #'list combinator (if rest-p rest-type default-type))
 			   (subseq types2 (length types1))))
 

--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -418,10 +418,12 @@
 		  (append
            (mapcar (lambda (type1 type2)
                      (let ((combined (list combinator type1 type2)))
-                       (cond ((and (subtypep type1 combined)
+                       (cond ((and (not (type= nil type1))
+                                   (subtypep type1 combined)
                                    (subtypep type1 type2))
                               type1)
-                             ((and (subtypep type2 combined)
+                             ((and (not (type= nil type2))
+                                   (subtypep type2 combined)
                                    (subtypep type2 type1))
                               type2)
                              (t

--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -418,9 +418,11 @@
 		  (append
            (mapcar (lambda (type1 type2)
                      (let ((combined (list combinator type1 type2)))
-                       (cond ((subtypep type1 combined)
+                       (cond ((and (subtypep type1 combined)
+                                   (subtypep type1 type2))
                               type1)
-                             ((subtypep type2 combined)
+                             ((and (subtypep type2 combined)
+                                   (subtypep type2 type1))
                               type2)
                              (t
                               combined))))

--- a/test/values-types.lisp
+++ b/test/values-types.lisp
@@ -65,11 +65,11 @@
 (test combine-simple-types
   "Test combining two simple types (no VALUES specifiers)"
 
-  (is (equal
-       '(and integer (eql 10))
+  (is (type=
+       '(eql 10)
        (combine-values-types 'and 'integer '(eql 10))))
 
-  (is (equal
+  (is (type=
        '(or number character)
        (combine-values-types 'or 'number 'character))))
 


### PR DESCRIPTION
This avoids creating chains like `(and t t t some-non-t-type)` and aids debuggability.