### PR TITLE
For special-form-type CL:THE avoid using value-form on CCL

### DIFF
--- a/src/form-types.lisp
+++ b/src/form-types.lisp
@@ -813,7 +813,11 @@
 (defmethod special-form-type ((operator (eql 'cl:the)) operands env)
   (match-form operands
     ((list type value-form)
-     (combine-values-types 'and type (form-type% value-form env) t))))
+     #-ccl
+     (combine-values-types 'and type (form-type% value-form env) t)
+     ;;; On CCL, CL:AREF has a compiler macro that can lead to stackoverflow.
+     #+ccl
+     type)))
 
 ;;;; LOAD-TIME-VALUE
 


### PR DESCRIPTION
On CCL, `(CL:AREF (THE (SIMPLE-ARRAY SINGLE-FLOAT) A) 0)` can compiler macroexpand into

    (CL:THE SINGLE-FLOAT (CL:AREF (THE (SIMPLE-ARRAY SINGLE-FLOAT) A) 0))

And this can subsequently lead to infinite expansion and stack overflow.