### PR TITLE
Type inference for math functions in ANSI standard

### DIFF
--- a/cl-form-types.asd
+++ b/cl-form-types.asd
@@ -66,6 +66,7 @@
 		 (:file "special-forms")
 		 (:file "block-types")
 		 (:file "custom-types")
+                 (:file "math-operations")
                  (:file "walker"))))
 
   :perform (test-op (o s)

--- a/src/cl-functions.lisp
+++ b/src/cl-functions.lisp
@@ -171,3 +171,162 @@
      (maybe-constant-form-value type env :default t))
 
     (_ t)))
+
+(defstruct (numeric-op (:conc-name %numeric-op-))
+  closed-under-fixnum-p
+  closed-under-integers-p
+  closed-under-rationals-p
+  closed-under-float-p
+  result-necessarily-float-p
+  result-necessarily-integer-p
+  result-necessarily-real-p)
+
+(macrolet ((def (slot-name)
+             `(defun ,(symbolicate 'numeric-op '- slot-name) (op)
+                (multiple-value-bind (value existsp)
+                    (gethash op *numeric-op-table*)
+                  (if existsp
+                      (,(symbolicate '%numeric-op- slot-name) value)
+                      nil)))))
+  (def closed-under-fixnum-p)
+  (def closed-under-integers-p)
+  (def closed-under-rationals-p)
+  (def closed-under-float-p)
+  (def result-necessarily-float-p)
+  (def result-necessarily-integer-p)
+  (def result-necessarily-real-p))
+
+(defparameter *numeric-op-table*
+  (alist-hash-table
+   (nconc
+    (list (cons '+ (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p t   :closed-under-rationals-p t :closed-under-float-p t))
+          (cons '- (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p t   :closed-under-rationals-p t :closed-under-float-p t))
+          (cons '* (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p t   :closed-under-rationals-p t :closed-under-float-p t))
+          (cons '/ (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p nil :closed-under-rationals-p t :closed-under-float-p t))
+
+          (cons '1+ (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p t :closed-under-rationals-p t :closed-under-float-p t))
+          (cons '1- (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p t :closed-under-rationals-p t :closed-under-float-p t)))
+
+    #+sbcl
+    (list (cons 'max (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :closed-under-float-p t :result-necessarily-real-p t))
+          (cons 'min (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :closed-under-float-p t :result-necessarily-real-p t)))
+
+    ;; Implementations are free to decide whether to apply contagions or not: http://clhs.lisp.se/Body/f_max_m.htm
+    #-sbcl
+    (list (cons 'max (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p nil :closed-under-rationals-p nil :closed-under-float-p nil :result-necessarily-real-p t))
+          (cons 'min (make-numeric-op :closed-under-fixnum-p nil :closed-under-integers-p nil :closed-under-rationals-p nil :closed-under-float-p nil :result-necessarily-real-p t)))
+
+    (list (cons 'floor    (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :result-necessarily-integer-p t))
+          (cons 'ceiling  (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :result-necessarily-integer-p t))
+          (cons 'truncate (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :result-necessarily-integer-p t))
+          (cons 'round    (make-numeric-op :closed-under-fixnum-p t :closed-under-integers-p t :closed-under-rationals-p t :result-necessarily-integer-p t))
+
+          (cons 'ffloor    (make-numeric-op :closed-under-float-p t :result-necessarily-float-p t))
+          (cons 'fceiling  (make-numeric-op :closed-under-float-p t :result-necessarily-float-p t))
+          (cons 'ftruncate (make-numeric-op :closed-under-float-p t :result-necessarily-float-p t))
+          (cons 'fround    (make-numeric-op :closed-under-float-p t :result-necessarily-float-p t)))
+
+    #+sbcl
+    (list (cons 'sin (make-numeric-op :result-necessarily-float-p t))
+          (cons 'cos (make-numeric-op :result-necessarily-float-p t))
+          (cons 'tan (make-numeric-op :result-necessarily-float-p t)))
+    #-sbcl
+    (list (cons 'sin (make-numeric-op))
+          (cons 'cos (make-numeric-op))
+          (cons 'tan (make-numeric-op))))))
+
+(defun numeric-result-type (op arg-types env)
+
+  (flet ((some-subtypep (type)
+           (some (lambda (arg-type)
+                   (subtypep arg-type type env))
+                 arg-types))
+         (all-subtypep (type)
+           (every (lambda (arg-type)
+                    (subtypep arg-type type env))
+                  arg-types)))
+
+    (let* ((realp (numeric-op-result-necessarily-real-p op))
+           (complex-possible-p (not realp)))
+
+      (when (numeric-op-closed-under-fixnum-p op)
+        (when (all-subtypep 'fixnum)
+          (return-from numeric-result-type 'fixnum))
+        (when (and complex-possible-p
+                   (all-subtypep '(complex fixnum)))
+          (return-from numeric-result-type '(complex fixnum))))
+
+      (when (numeric-op-closed-under-integers-p op)
+        (when (all-subtypep 'integer)
+          (return-from numeric-result-type 'integer))
+        (when (and complex-possible-p
+                   (all-subtypep '(complex integer)))
+          (return-from numeric-result-type '(complex integer))))
+
+      (when (numeric-op-closed-under-rationals-p op)
+        (when (all-subtypep 'rational)
+          (return-from numeric-result-type 'rational))
+        (when (and complex-possible-p
+                   (all-subtypep '(complex rational)))
+          (return-from numeric-result-type '(complex rational))))
+
+      (when (numeric-op-closed-under-float-p op)
+        (when (all-subtypep 'single-float)
+          (return-from numeric-result-type 'single-float))
+        (when (all-subtypep 'double-float)
+          (return-from numeric-result-type 'double-float))
+
+        (when complex-possible-p
+          (when (all-subtypep '(complex single-float))
+            (return-from numeric-result-type '(complex single-float)))
+          (when (all-subtypep '(complex double-float))
+            (return-from numeric-result-type '(complex double-float)))))
+
+      (when (numeric-op-result-necessarily-integer-p op)
+        (return-from numeric-result-type 'integer))
+
+      (when (numeric-op-result-necessarily-float-p op)
+        (when (some-subtypep 'double-float)
+          (return-from numeric-result-type 'double-float))
+        ;; What happens if all the results are rational?
+        (return-from numeric-result-type 'single-float))
+
+      (return-from numeric-result-type 'number))))
+
+(defun every-eql-type-p (types env)
+  (let (values)
+    (every (lambda (type)
+             (optima:match type
+               ((list 'eql value)
+                (push value values))
+               (_
+                (return-from every-eql-type-p
+                  (values nil nil)))))
+           types)
+    (values t (nreverse values))))
+
+(defun numeric-op-form-type (op args env)
+  (let ((arg-types (mapcar (lambda (arg)
+                             (introspect-environment:typexpand
+                              (form-type arg env)
+                              env))
+                           args)))
+    (multiple-value-bind (all-eql-p values)
+        (every-eql-type-p arg-types env)
+      (cond (all-eql-p
+             (or (ignore-errors `(eql ,(apply op values)))
+                 `number))
+            (t
+             (numeric-result-type op arg-types env))))))
+
+(macrolet ((def (&rest ops)
+             `(progn
+                ,@(mapcar (lambda (op)
+                            `(defmethod custom-form-type ((op (eql ',op)) args env)
+                               (numeric-op-form-type op args env)))
+                          ops))))
+  (def + - / * 1+ 1- max min
+    floor ceiling truncate round
+    ffloor fceiling fruncate fround
+
+    sin cos tan atan))

--- a/src/cl-functions.lisp
+++ b/src/cl-functions.lisp
@@ -308,7 +308,7 @@
 (defun numeric-op-form-type (op args env)
   (let ((arg-types (mapcar (lambda (arg)
                              (introspect-environment:typexpand
-                              (form-type arg env)
+                              (nth-form-type arg env 0)
                               env))
                            args)))
     (multiple-value-bind (all-eql-p values)

--- a/test/math-operations.lisp
+++ b/test/math-operations.lisp
@@ -48,8 +48,8 @@
 
 ;;; Tests
 
-(test (math+ :compile-at :run-time)
-  "Test FORM-TYPE on (+ ...) forms"
+(test (math+-same-types :compile-at :run-time)
+  "Test FORM-TYPE on (+ ...) forms with arguments of same type"
 
   (let ((a 1) (b 2) (c 3))
     (declare (ignorable a b c))
@@ -59,17 +59,47 @@
       :strict t)
 
     (is-form-type integer
-      (+ (the integer a) (the integer b) (the integer c)))
+      (+ (the integer a) (the integer b) (the integer c))
+      :strict t)
 
     (is-form-type rational
-      (+ (the rational a) (the rational b) (the rational c)))
+      (+ (the rational a) (the rational b) (the rational c))
+      :strict t)
 
     (is-form-type float
       (+ (the float a) (the float b) (the float c))
       :strict t)
 
     (is-form-type single-float
-      (+ (the single-float a) (the single-float b) (the single-float c)))
+      (+ (the single-float a) (the single-float b) (the single-float c))
+      :strict t)
 
     (is-form-type double-float
-      (+ (the double-float a) (the double-float b) (the double-float c)))))
+      (+ (the double-float a) (the double-float b) (the double-float c))
+      :strict t)))
+
+(test (math+-different-types :compile-at :run-time)
+  "Test FORM-TYPE on (+ ...) forms with arguments of different type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (+ (the fixnum a) (the fixnum b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (+ (the integer a) (the rational b) (the integer c))
+      :strict t)
+
+    (is-form-type float
+      (+ (the float a) (the single-float b) (the double-float c))
+      :strict t)
+
+    (is-form-type float
+      (+ (the double-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type number
+      (+ (the rational a) (the float b) (the double-float c))
+      :strict t)))

--- a/test/math-operations.lisp
+++ b/test/math-operations.lisp
@@ -1,0 +1,75 @@
+;;;; math-operations.lisp
+;;;;
+;;;; Copyright 2023 Alexander Gutev <alex.gutev@gmail.com>
+;;;;
+;;;; Permission is hereby granted, free of charge, to any person
+;;;; obtaining a copy of this software and associated documentation
+;;;; files (the "Software"), to deal in the Software without
+;;;; restriction, including without limitation the rights to use,
+;;;; copy, modify, merge, publish, distribute, sublicense, and/or sell
+;;;; copies of the Software, and to permit persons to whom the
+;;;; Software is furnished to do so, subject to the following
+;;;; conditions:
+;;;;
+;;;; The above copyright notice and this permission notice shall be
+;;;; included in all copies or substantial portions of the Software.
+;;;;
+;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;; OTHER DEALINGS IN THE SOFTWARE.
+
+;;;; Unit tests for type deduction logic of mathematical functions in
+;;;; CL standard
+
+(defpackage :cl-form-types/test.math-operations
+  (:use :cl-environments-cl
+	:cl-form-types
+	:alexandria
+
+	:fiveam
+	:cl-form-types/test))
+
+(in-package :cl-form-types/test.math-operations)
+
+
+;;; Test Suite Definition
+
+(def-suite math-operations
+    :description "Test type deduction logic for mathematical functions"
+    :in cl-form-types)
+
+(in-suite math-operations)
+
+
+;;; Tests
+
+(test (math+ :compile-at :run-time)
+  "Test FORM-TYPE on (+ ...) forms"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (+ (the fixnum a) (the fixnum b) (the fixnum c))
+      :strict t)
+
+    (is-form-type integer
+      (+ (the integer a) (the integer b) (the integer c)))
+
+    (is-form-type rational
+      (+ (the rational a) (the rational b) (the rational c)))
+
+    (is-form-type float
+      (+ (the float a) (the float b) (the float c))
+      :strict t)
+
+    (is-form-type single-float
+      (+ (the single-float a) (the single-float b) (the single-float c)))
+
+    (is-form-type double-float
+      (+ (the double-float a) (the double-float b) (the double-float c)))))

--- a/test/math-operations.lisp
+++ b/test/math-operations.lisp
@@ -46,9 +46,9 @@
 (in-suite math-operations)
 
 
-;;; Tests
+;;; + function
 
-(test (math+-same-types :compile-at :run-time)
+(test (+-same-types :compile-at :run-time)
   "Test FORM-TYPE on (+ ...) forms with arguments of same type"
 
   (let ((a 1) (b 2) (c 3))
@@ -78,7 +78,7 @@
       (+ (the double-float a) (the double-float b) (the double-float c))
       :strict t)))
 
-(test (math+-different-types :compile-at :run-time)
+(test (+-different-types :compile-at :run-time)
   "Test FORM-TYPE on (+ ...) forms with arguments of different type"
 
   (let ((a 1) (b 2) (c 3))
@@ -102,4 +102,245 @@
 
     (is-form-type number
       (+ (the rational a) (the float b) (the double-float c))
+      :strict t)))
+
+
+;;; - function
+
+(test (minus-same-types :compile-at :run-time)
+  "Test FORM-TYPE on (- ...) forms with arguments of same type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (- (the fixnum a) (the fixnum b) (the fixnum c))
+      :strict t)
+
+    (is-form-type integer
+      (- (the integer a) (the integer b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (- (the rational a) (the rational b) (the rational c))
+      :strict t)
+
+    (is-form-type float
+      (- (the float a) (the float b) (the float c))
+      :strict t)
+
+    (is-form-type single-float
+      (- (the single-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type double-float
+      (- (the double-float a) (the double-float b) (the double-float c))
+      :strict t)))
+
+(test (minus-different-types :compile-at :run-time)
+  "Test FORM-TYPE on (- ...) forms with arguments of different type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (- (the fixnum a) (the fixnum b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (- (the integer a) (the rational b) (the integer c))
+      :strict t)
+
+    (is-form-type float
+      (- (the float a) (the single-float b) (the double-float c))
+      :strict t)
+
+    (is-form-type float
+      (- (the double-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type number
+      (- (the rational a) (the float b) (the double-float c))
+      :strict t)))
+
+
+;;; * function
+
+(test (*-same-types :compile-at :run-time)
+  "Test FORM-TYPE on (* ...) forms with arguments of same type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (* (the fixnum a) (the fixnum b) (the fixnum c))
+      :strict t)
+
+    (is-form-type integer
+      (* (the integer a) (the integer b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (* (the rational a) (the rational b) (the rational c))
+      :strict t)
+
+    (is-form-type float
+      (* (the float a) (the float b) (the float c))
+      :strict t)
+
+    (is-form-type single-float
+      (* (the single-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type double-float
+      (* (the double-float a) (the double-float b) (the double-float c))
+      :strict t)))
+
+(test (*-different-types :compile-at :run-time)
+  "Test FORM-TYPE on (* ...) forms with arguments of different type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type integer
+      (* (the fixnum a) (the fixnum b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (* (the integer a) (the rational b) (the integer c))
+      :strict t)
+
+    (is-form-type float
+      (* (the float a) (the single-float b) (the double-float c))
+      :strict t)
+
+    (is-form-type float
+      (* (the double-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type number
+      (* (the rational a) (the float b) (the double-float c))
+      :strict t)))
+
+
+;;; / function
+
+(test (/-same-types :compile-at :run-time)
+  "Test FORM-TYPE on (/ ...) forms with arguments of same type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type rational
+      (/ (the fixnum a) (the fixnum b) (the fixnum c))
+      :strict t)
+
+    (is-form-type rational
+      (/ (the integer a) (the integer b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (/ (the rational a) (the rational b) (the rational c))
+      :strict t)
+
+    (is-form-type float
+      (/ (the float a) (the float b) (the float c))
+      :strict t)
+
+    (is-form-type single-float
+      (/ (the single-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type double-float
+      (/ (the double-float a) (the double-float b) (the double-float c))
+      :strict t)))
+
+(test (/-different-types :compile-at :run-time)
+  "Test FORM-TYPE on (/ ...) forms with arguments of different type"
+
+  (let ((a 1) (b 2) (c 3))
+    (declare (ignorable a b c))
+
+    (is-form-type rational
+      (/ (the fixnum a) (the fixnum b) (the integer c))
+      :strict t)
+
+    (is-form-type rational
+      (/ (the integer a) (the rational b) (the integer c))
+      :strict t)
+
+    (is-form-type float
+      (/ (the float a) (the single-float b) (the double-float c))
+      :strict t)
+
+    (is-form-type float
+      (/ (the double-float a) (the single-float b) (the single-float c))
+      :strict t)
+
+    (is-form-type number
+      (/ (the rational a) (the float b) (the double-float c))
+      :strict t)))
+
+
+
+;;; 1+ and 1- functions
+
+(test (1+ :compile-at :run-time)
+  "Test FORM-TYPE on (1+ ...) forms with arguments of same type"
+
+  (let ((a 1))
+    (declare (ignorable a))
+
+    (is-form-type integer
+      (1+ (the fixnum a))
+      :strict t)
+
+    (is-form-type integer
+      (1+ (the integer a))
+      :strict t)
+
+    (is-form-type rational
+      (1+ (the rational a))
+      :strict t)
+
+    (is-form-type float
+      (1+ (the float a))
+      :strict t)
+
+    (is-form-type single-float
+      (1+ (the single-float a))
+      :strict t)
+
+    (is-form-type double-float
+      (1+ (the double-float a))
+      :strict t)))
+
+(test (1- :compile-at :run-time)
+  "Test FORM-TYPE on (1- ...) forms with arguments of same type"
+
+  (let ((a 1))
+    (declare (ignorable a))
+
+    (is-form-type integer
+      (1- (the fixnum a))
+      :strict t)
+
+    (is-form-type integer
+      (1- (the integer a))
+      :strict t)
+
+    (is-form-type rational
+      (1- (the rational a))
+      :strict t)
+
+    (is-form-type float
+      (1- (the float a))
+      :strict t)
+
+    (is-form-type single-float
+      (1- (the single-float a))
+      :strict t)
+
+    (is-form-type double-float
+      (1- (the double-float a))
       :strict t)))


### PR DESCRIPTION
Adding type inference for math functions is going to be a long project. Here are the initial steps in case anyone wants to build upon them. I will probably push to this as and when need them in other projects.

I don't think this should be merged without adding a good number of tests because this can break other code relying on correct behavior of cl-form-types.

Reference:

1. http://clhs.lisp.se/Body/c_number.htm
2. http://clhs.lisp.se/Body/12_a.htm